### PR TITLE
add package_python.sh and setup.py.template

### DIFF
--- a/package_python.sh
+++ b/package_python.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+version=`grep -oP -m 1 '<version>\K([^<]+)' pom.xml`
+
+set +e
+rm -r target/python/${version}
+
+set -e
+home=`pwd`
+for dic_type in small core full
+do
+    temp=target/python/${version}/${dic_type}
+    pkg=${temp}/sudachidict_${dic_type}
+    mkdir -p ${pkg}/resources/
+    touch ${pkg}/__init__.py
+    cp target/system_${dic_type}.dic ${pkg}/resources/system.dic
+    cp README.md ${temp}
+    cat setup.py.template | sed "s/%%VERSION%%/${version}/g" | sed "s/%%DIC_TYPE%%/${dic_type}/g" > ${temp}/setup.py
+    cd ${temp}
+    python setup.py sdist
+    cp dist/*.tar.gz ${home}/target/
+    cd ${home}
+    rm -r ${temp}
+done
+rm -r target/python/${version}

--- a/setup.py.template
+++ b/setup.py.template
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+
+def load_text(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+package = "sudachidict_%%DIC_TYPE%%"
+
+
+setup(name="SudachiDict_%%DIC_TYPE%%",
+      version="%%VERSION%%",
+      description="A lexicon for Sudachi, the Japanese Morphological Analyzer",
+      long_description=load_text("README.md"),
+      long_description_content_type="text/markdown",
+      author="Works Applications Co.,Ltd.",
+      author_email="takaoka_k@worksap.co.jp",
+      url="https://github.com/WorksApplications/SudachiDict",
+      license="Apache-2.0",
+      packages=[package],
+      package_data={package: ["__init__.py", "resources/system.dic", "resources/README.md"]},
+      install_requires=["SudachiPy>=0.2.1"],
+      )


### PR DESCRIPTION
@kazuma-t Could you review this packaging script for python? It's simple and will take few minutes.

It generates three types of packages:
- SudachiDict_small
- SudachiDict_core
- SudachiDict_full

I used python 3.7.2 for testing.