### PR TITLE
Fixes UnicodeDecodeError (on windows)

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -50,7 +50,7 @@ if not os.path.exists(RESOURCE_DIR):
     os.remove(ZIP_NAME)
     logger.warning("... downloaded and placed the dictionary at `{}`.".format(RESOURCE_DIR))
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Installing the latest version of `SudachiDict-core` on Windows yields the following exception. Because on Windows the local encoding (and not UTF-8) is used to read `README.md`. The issue occurred only recently because Japanese text was added to the readme, which requires the correct encoding to be used now.

```
Traceback (most recent call last):
	File "<string>", line 1, in <module>
	File \setup.py", line 54, in <module>
		long_description = fh.read()
	File \Python38\lib\encodings\cp1252.py", line 23, in decode
		return codecs.charmap_decode(input,self.errors,decoding_table)[0]
	UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1272: character maps to <undefined>
```