### PR TITLE
Change SudachiPy version requirement

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -66,6 +66,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={"": ["resources/*"]},
     install_requires=[
-        "SudachiPy~=0.5.0"
+        "SudachiPy>=0.5.0"
     ],
 )


### PR DESCRIPTION
The python bindings of sudachi.rs will be released as SudachiPy v0.6.*.
Update the requirement in the `setup.py` to support it.
