### PR TITLE
Update Unidic Licenses URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ SudachiDict by Works Applications Co., Ltd. is licensed under the [Apache Licens
 This project includes UniDic and a part of NEologd.
 ```
 
-- <http://unidic.ninjal.ac.jp/>
+- <https://clrd.ninjal.ac.jp/unidic/>
 - <https://github.com/neologd/mecab-ipadic-neologd>


### PR DESCRIPTION
I've updated the outdated UniDic URL (http://unidic.ninjal.ac.jp/) to the current official site (https://clrd.ninjal.ac.jp/unidic/). The original link appears to be no longer accessible, and the new URL is the correct and maintained resource.